### PR TITLE
Addition of cdp feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # extended_bashrc
+* Git branch
 This bashrc shows on which repo I am working (and at which branch).
 
 To use this extension, run the following:
@@ -52,3 +53,23 @@ In your ~/.bashrc add the following line after the previous lines:
 # Overwrites PS1
 source PATH_TO_THIS_GIT_REPO/bashrc_ext
 </pre>
+
+* cdp 
+In order to use the cd shorthand function, create a config file ~/.cdp.config for example:
+
+<pre>
+# Config file for cdp shorthand, see https://github.com/mathijsdelangen/extended_bashrc
+# Shorthands are only reloaded when bash is reloaded!
+declare -A project_paths
+
+# Do not use ~, use $HOME instead
+project_paths["home"]="$HOME"
+project_paths["fms"]="/data/projects/agvsol/okkhen/prg/fms/work"
+project_paths["fms-n"]="$HOME/projects/OP6996/AGVSOL151428/Rxx"
+project_paths["fmsdoc"]="/data/projects/agvsol/okkhen/docs/fms/work"
+project_paths["dsd"]="/data/projects/dsd3a/okkhen/work"
+project_paths["dsd-n"]="$HOME/projects/TKT6475/FCSD3A150071/Rxx/Prg/okkhen/work"
+project_paths["avidis"]="/data/projects/avidis/"
+project_paths["pors"]="/data/projects/ic/okkhen/"
+</pre>
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # extended_bashrc
-* Git branch
+## Git branch
 This bashrc shows on which repo I am working (and at which branch).
 
 To use this extension, run the following:
@@ -54,7 +54,7 @@ In your ~/.bashrc add the following line after the previous lines:
 source PATH_TO_THIS_GIT_REPO/bashrc_ext
 </pre>
 
-* cdp 
+## cdp 
 In order to use the cd shorthand function, create a config file ~/.cdp.config for example:
 
 <pre>

--- a/README.md
+++ b/README.md
@@ -55,12 +55,20 @@ source PATH_TO_THIS_GIT_REPO/bashrc_ext
 </pre>
 
 ## cdp 
-In order to use the cd shorthand function, create a config file ~/.cdp.config for example:
+cdp enables you to create a config file with directory shorthands, to for example project directories. 
+By typing cdp <shorthand> (or by using tab completion) you can quickly change to the configured directory.
+
+In order to use the cd shorthand function, create a config file:
+
+<pre>
+~/.cdp.config
+</pre>
+
+This is an example cdp.config file:
 
 <pre>
 # Config file for cdp shorthand, see https://github.com/mathijsdelangen/extended_bashrc
 # Shorthands are only reloaded when bash is reloaded!
-declare -A project_paths
 
 # Do not use ~, use $HOME instead
 project_paths["home"]="$HOME"
@@ -72,4 +80,5 @@ project_paths["dsd-n"]="$HOME/projects/TKT6475/FCSD3A150071/Rxx/Prg/okkhen/work"
 project_paths["avidis"]="/data/projects/avidis/"
 project_paths["pors"]="/data/projects/ic/okkhen/"
 </pre>
+
 

--- a/README.md
+++ b/README.md
@@ -72,13 +72,9 @@ This is an example cdp.config file:
 
 # Do not use ~, use $HOME instead
 project_paths["home"]="$HOME"
-project_paths["fms"]="/data/projects/agvsol/okkhen/prg/fms/work"
-project_paths["fms-n"]="$HOME/projects/OP6996/AGVSOL151428/Rxx"
-project_paths["fmsdoc"]="/data/projects/agvsol/okkhen/docs/fms/work"
-project_paths["dsd"]="/data/projects/dsd3a/okkhen/work"
-project_paths["dsd-n"]="$HOME/projects/TKT6475/FCSD3A150071/Rxx/Prg/okkhen/work"
-project_paths["avidis"]="/data/projects/avidis/"
-project_paths["pors"]="/data/projects/ic/okkhen/"
+project_paths["project1"]="/data/projects/project1/work"
+project_paths["project1-n"]="$HOME/projects/company3/project1/Rxx"
+project_paths["paard-docs"]="/data/projects/paard/docs/work"
 </pre>
 
 

--- a/bashrc_ext
+++ b/bashrc_ext
@@ -22,3 +22,48 @@ function cd () {
    builtin cd "${@:1:$n-1}" $(sed -e$e -e$e -e$e <<< "${!n}");
  fi
 }
+
+
+FILE="${HOME}/.cdp.config"
+if [ -f $FILE ]; then
+    # (Re)load config file
+    source ~/.cdp.config
+else
+    declare -A project_paths
+    project_paths["home"]="$HOME"
+fi
+
+# cdp - change directory to map of paths
+function get_project_path_keys() {
+	keys=""
+	for key in "${!project_paths[@]}"; do
+		keys="$keys $key"
+	done
+	echo $keys
+}
+
+function cdp() {
+	if [[ $# -eq 0 ]] ; then
+		echo "Pass one of the project shorthands as first argument"
+		for key in "${!project_paths[@]}"; do
+			echo "  $key"
+		done
+		return 1
+	fi
+	
+	base_path=${project_paths["$1"]}
+	if [ "$base_path" = "" ]; then
+		echo "No path defined for '$1'"
+		return 1;
+	fi
+	
+	expanded_path=$(readlink -f "$base_path")
+	if [[ $# -eq 1 ]] ; then
+		cd $expanded_path
+	else
+		cd $expanded_path/${@:2}
+	fi
+}
+
+_cdp_options=$(get_project_path_keys)
+complete -W "${_cdp_options}" -o dirnames 'cdp'

--- a/bashrc_ext
+++ b/bashrc_ext
@@ -24,12 +24,13 @@ function cd () {
 }
 
 
-FILE="${HOME}/.cdp.config"
-if [ -f $FILE ]; then
-    # (Re)load config file
+declare -A project_paths
+CDP_CONFIG_FILE="${HOME}/.cdp.config"
+if [ -f $CDP_CONFIG_FILE ]; then
+    # Load the cdp.config file
     source ~/.cdp.config
 else
-    declare -A project_paths
+    # Load a default setting
     project_paths["home"]="$HOME"
 fi
 
@@ -43,6 +44,10 @@ function get_project_path_keys() {
 }
 
 function cdp() {
+	if [ ! -f $CDP_CONFIG_FILE ]; then
+		echo "You do not have a configuration file: ~/.cdp-config"
+	fi
+
 	if [[ $# -eq 0 ]] ; then
 		echo "Pass one of the project shorthands as first argument"
 		for key in "${!project_paths[@]}"; do


### PR DESCRIPTION
cdp enables you to create a config file with directory shorthands, to for example project directories. 
By typing cdp <shorthand> (or by using tab completion) you can quickly change to the configured directory.